### PR TITLE
[fix] 성과 헤더 오류수정 (#70)

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -18,11 +18,13 @@
 <script setup>
 import { ref, computed, watch } from 'vue'
 import { useRouter, useRoute } from 'vue-router'
+import { usePerformanceStore } from '@/store/performance'
 import Headerbar from '@/components/layout/Headerbar.vue'
 import Sidebar from '@/components/layout/Sidebar.vue'
 
 const router = useRouter()
 const route = useRoute()
+const perfStore = usePerformanceStore()
 const activeNav = ref('메인')
 
 // 로그인 페이지에서는 레이아웃 숨기기
@@ -34,7 +36,10 @@ const handleNavClick = (nav) => {
   if (nav === '메인') router.push('/')
   else if (nav === '인사') router.push('/hr')
   else if (nav === '전자결재') router.push('/approval')
-  else if (nav === '성과') router.push('/performance')
+  else if (nav === '성과') {
+    perfStore.setPage('dashboard')
+    router.push('/performance')
+  }
   else if (nav === '근태') router.push('/attendance/my')
   else if (nav === '급여') router.push('/salary/my')
   else if (nav === 'KMS') router.push('/kms')


### PR DESCRIPTION
## 📌 관련 이슈
- Closes #70 

## 📝 변경 사항
헤더에서 성과를 선택했을 시 대시보드로 가지않는 오류 수정


## 🛠 작업 유형
- [x] 🐞 버그 수정 (Bug Fix)
- [ ] ✨ 신규 기능 (New Feature)
- [ ] ♻️ 리팩토링 (Refactoring)
- [ ] 🎨 스타일/UI 수정 (Style/UI)
- [ ] 📝 문서 업데이트 (Documentation)
- [ ] 🔧 설정 변경 (Config)

## ✅ 체크리스트
- [ ] 브라우저에서 화면이 잘 보이는지 확인했나요? (Chrome, Safari 등)
- [ ] 모바일/태블릿 화면(반응형)에서 깨짐이 없나요?
- [ ] 불필요한 `console.log`나 주석을 제거했나요?
- [ ] 코딩 컨벤션(Prettier/ESLint)을 준수했나요?

## 🎸 기타


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  - 성과 페이지 접근 시 애플리케이션의 초기화 과정이 개선되어 더욱 안정적이고 신뢰성 높은 환경을 제공합니다.
  - 성과 섹션으로 이동할 때 필요한 초기 설정이 자동으로 실행되도록 업데이트되어 사용자의 편의성이 크게 향상되었습니다.
  - 애플리케이션의 페이지 네비게이션 흐름이 효율적으로 최적화되어 전반적인 사용자 경험이 개선되었습니다.
  - 애플리케이션 내부 상태 관리 기능이 강화되어 더욱 견고한 시스템 구조를 갖추게 되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->